### PR TITLE
feat: add connection visualizer to db-health module

### DIFF
--- a/package/api/src/modules/db-health/controller.ts
+++ b/package/api/src/modules/db-health/controller.ts
@@ -35,4 +35,15 @@ export const dbHealthController = {
     const indexes = await dbHealthService.getUnusedIndexes();
     res.json(indexes);
   }),
+
+  getConnectionTopology: asyncHandler(async (_req: Request, res: Response) => {
+    const topology = await dbHealthService.getConnectionTopology();
+    res.json(topology);
+  }),
+
+  getConnectionHealth: asyncHandler(async (req: Request, res: Response) => {
+    const minDuration = parseFloat(req.query.min_duration as string) || 5;
+    const health = await dbHealthService.getConnectionHealth(minDuration);
+    res.json(health);
+  }),
 };

--- a/package/api/src/modules/db-health/routes.ts
+++ b/package/api/src/modules/db-health/routes.ts
@@ -9,5 +9,7 @@ router.get('/slow-queries', dbHealthController.getSlowQueries);
 router.get('/tables', dbHealthController.getTables);
 router.get('/indexes', dbHealthController.getIndexes);
 router.get('/indexes/unused', dbHealthController.getUnusedIndexes);
+router.get('/connections/topology', dbHealthController.getConnectionTopology);
+router.get('/connections/health', dbHealthController.getConnectionHealth);
 
 export { router as dbHealthRouter };

--- a/package/api/src/modules/db-health/service.ts
+++ b/package/api/src/modules/db-health/service.ts
@@ -60,7 +60,8 @@ export class DbHealthService {
   }
 
   async getSlowQueries(minDurationSeconds = 5) {
-    const result = await pool.query(`
+    const result = await pool.query(
+      `
       SELECT
         pid, usename, query,
         EXTRACT(EPOCH FROM (now() - query_start))::float as duration_seconds,
@@ -71,7 +72,9 @@ export class DbHealthService {
         AND query_start IS NOT NULL
         AND EXTRACT(EPOCH FROM (now() - query_start)) > $1
       ORDER BY query_start ASC
-    `, [minDurationSeconds]);
+    `,
+      [minDurationSeconds]
+    );
     return result.rows;
   }
 
@@ -114,5 +117,78 @@ export class DbHealthService {
       ORDER BY pg_relation_size(indexrelid) DESC
     `);
     return result.rows;
+  }
+
+  async getConnectionTopology() {
+    const result = await pool.query(`
+      SELECT
+        application_name,
+        count(*)::int as total,
+        count(*) FILTER (WHERE state = 'active')::int as active,
+        count(*) FILTER (WHERE state = 'idle')::int as idle,
+        count(*) FILTER (WHERE state = 'idle in transaction')::int as idle_in_transaction
+      FROM pg_stat_activity
+      WHERE datname = current_database()
+        AND pid != pg_backend_pid()
+      GROUP BY application_name
+      ORDER BY total DESC
+    `);
+    return result.rows;
+  }
+
+  async getIdleInTransaction() {
+    const result = await pool.query(`
+      SELECT
+        pid, usename, application_name, client_addr::text,
+        EXTRACT(EPOCH FROM (now() - xact_start))::float as duration_seconds,
+        query, state
+      FROM pg_stat_activity
+      WHERE state = 'idle in transaction'
+        AND datname = current_database()
+      ORDER BY xact_start ASC
+    `);
+    return result.rows;
+  }
+
+  async getBlockedConnections() {
+    const result = await pool.query(`
+      SELECT
+        blocked.pid as blocked_pid,
+        blocked.usename as blocked_user,
+        blocked.application_name as blocked_app,
+        blocked.query as blocked_query,
+        EXTRACT(EPOCH FROM (now() - blocked.query_start))::float as waiting_seconds,
+        blocking.pid as blocking_pid,
+        blocking.usename as blocking_user,
+        blocking.application_name as blocking_app,
+        blocking.query as blocking_query
+      FROM pg_locks blocked_locks
+      JOIN pg_stat_activity blocked ON blocked.pid = blocked_locks.pid
+      JOIN pg_locks blocking_locks ON blocking_locks.locktype = blocked_locks.locktype
+        AND blocking_locks.database IS NOT DISTINCT FROM blocked_locks.database
+        AND blocking_locks.relation IS NOT DISTINCT FROM blocked_locks.relation
+        AND blocking_locks.page IS NOT DISTINCT FROM blocked_locks.page
+        AND blocking_locks.tuple IS NOT DISTINCT FROM blocked_locks.tuple
+        AND blocking_locks.virtualxid IS NOT DISTINCT FROM blocked_locks.virtualxid
+        AND blocking_locks.transactionid IS NOT DISTINCT FROM blocked_locks.transactionid
+        AND blocking_locks.classid IS NOT DISTINCT FROM blocked_locks.classid
+        AND blocking_locks.objid IS NOT DISTINCT FROM blocked_locks.objid
+        AND blocking_locks.objsubid IS NOT DISTINCT FROM blocked_locks.objsubid
+        AND blocking_locks.pid != blocked_locks.pid
+      JOIN pg_stat_activity blocking ON blocking.pid = blocking_locks.pid
+      WHERE NOT blocked_locks.granted
+        AND blocked.datname = current_database()
+    `);
+    return result.rows;
+  }
+
+  async getConnectionHealth(minDurationSeconds = 5) {
+    const [idleInTransaction, longRunningQueries, blockedConnections] = await Promise.all([
+      this.getIdleInTransaction(),
+      this.getSlowQueries(minDurationSeconds),
+      this.getBlockedConnections(),
+    ]);
+
+    return { idleInTransaction, longRunningQueries, blockedConnections };
   }
 }

--- a/package/api/src/modules/db-health/types.ts
+++ b/package/api/src/modules/db-health/types.ts
@@ -49,8 +49,48 @@ export const SlowQuerySchema = z.object({
   wait_event_type: z.string().nullable(),
 });
 
+export const ConnectionTopologySchema = z.object({
+  application_name: z.string().nullable(),
+  total: z.number(),
+  active: z.number(),
+  idle: z.number(),
+  idle_in_transaction: z.number(),
+});
+
+export const IdleTransactionSchema = z.object({
+  pid: z.number(),
+  usename: z.string().nullable(),
+  application_name: z.string().nullable(),
+  client_addr: z.string().nullable(),
+  duration_seconds: z.number(),
+  query: z.string().nullable(),
+  state: z.string(),
+});
+
+export const BlockedConnectionSchema = z.object({
+  blocked_pid: z.number(),
+  blocked_user: z.string().nullable(),
+  blocked_app: z.string().nullable(),
+  blocked_query: z.string().nullable(),
+  waiting_seconds: z.number(),
+  blocking_pid: z.number(),
+  blocking_user: z.string().nullable(),
+  blocking_app: z.string().nullable(),
+  blocking_query: z.string().nullable(),
+});
+
+export const ConnectionHealthSchema = z.object({
+  idleInTransaction: z.array(IdleTransactionSchema),
+  longRunningQueries: z.array(SlowQuerySchema),
+  blockedConnections: z.array(BlockedConnectionSchema),
+});
+
 export type ConnectionOverview = z.infer<typeof ConnectionOverviewSchema>;
 export type ConnectionDetail = z.infer<typeof ConnectionDetailSchema>;
 export type TableInfo = z.infer<typeof TableInfoSchema>;
 export type IndexInfo = z.infer<typeof IndexInfoSchema>;
 export type SlowQuery = z.infer<typeof SlowQuerySchema>;
+export type ConnectionTopology = z.infer<typeof ConnectionTopologySchema>;
+export type IdleTransaction = z.infer<typeof IdleTransactionSchema>;
+export type BlockedConnection = z.infer<typeof BlockedConnectionSchema>;
+export type ConnectionHealth = z.infer<typeof ConnectionHealthSchema>;

--- a/package/ui/app/(dashboard)/health/connections/page.tsx
+++ b/package/ui/app/(dashboard)/health/connections/page.tsx
@@ -1,0 +1,5 @@
+import { ConnectionsPage } from '@/modules/db-health/pages/connections';
+
+export default function Page() {
+  return <ConnectionsPage />;
+}

--- a/package/ui/modules/db-health/components/connection-health-alerts.tsx
+++ b/package/ui/modules/db-health/components/connection-health-alerts.tsx
@@ -1,0 +1,242 @@
+'use client';
+
+import { useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { ChevronDown, ChevronRight, AlertCircle, Clock, Lock } from 'lucide-react';
+import { ConnectionHealthData } from '../lib/api';
+
+interface ConnectionHealthAlertsProps {
+  health: ConnectionHealthData;
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds < 60) return `${seconds.toFixed(1)}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ${Math.floor(seconds % 60)}s`;
+  return `${Math.floor(seconds / 3600)}h ${Math.floor((seconds % 3600) / 60)}m`;
+}
+
+export function ConnectionHealthAlerts({ health }: ConnectionHealthAlertsProps) {
+  const [openSections, setOpenSections] = useState<Set<string>>(new Set());
+
+  const toggleSection = (section: string) => {
+    setOpenSections((prev) => {
+      const next = new Set(prev);
+      if (next.has(section)) next.delete(section);
+      else next.add(section);
+      return next;
+    });
+  };
+
+  const idleCount = health.idleInTransaction.length;
+  const slowCount = health.longRunningQueries.length;
+  const blockedCount = health.blockedConnections.length;
+
+  const longestIdle =
+    idleCount > 0 ? Math.max(...health.idleInTransaction.map((c) => c.duration_seconds)) : 0;
+  const longestSlow =
+    slowCount > 0 ? Math.max(...health.longRunningQueries.map((q) => q.duration_seconds)) : 0;
+  const longestBlocked =
+    blockedCount > 0 ? Math.max(...health.blockedConnections.map((c) => c.waiting_seconds)) : 0;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm font-medium">Connection Health</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {/* Idle in Transaction */}
+        <Collapsible open={openSections.has('idle')} onOpenChange={() => toggleSection('idle')}>
+          <CollapsibleTrigger className="flex items-center gap-3 w-full p-3 rounded-lg hover:bg-muted/50 transition-colors">
+            {openSections.has('idle') ? (
+              <ChevronDown className="h-4 w-4 shrink-0" />
+            ) : (
+              <ChevronRight className="h-4 w-4 shrink-0" />
+            )}
+            <AlertCircle
+              className={`h-4 w-4 shrink-0 ${idleCount > 0 ? 'text-red-500' : 'text-green-500'}`}
+            />
+            <span className="font-medium text-sm">{idleCount} idle-in-transaction</span>
+            {idleCount > 0 && (
+              <>
+                <Badge variant="outline" className="text-xs">
+                  longest: {formatDuration(longestIdle)}
+                </Badge>
+                <span className="text-xs text-muted-foreground">
+                  {[
+                    ...new Set(
+                      health.idleInTransaction.map((c) => c.application_name || '(unnamed)')
+                    ),
+                  ].join(', ')}
+                </span>
+              </>
+            )}
+            {idleCount === 0 && <span className="text-xs text-muted-foreground">Healthy</span>}
+          </CollapsibleTrigger>
+          {idleCount > 0 && (
+            <CollapsibleContent>
+              <div className="rounded-md border ml-7 mt-1">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>PID</TableHead>
+                      <TableHead>Application</TableHead>
+                      <TableHead>User</TableHead>
+                      <TableHead>Duration</TableHead>
+                      <TableHead>Query</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {health.idleInTransaction.map((c) => (
+                      <TableRow key={c.pid}>
+                        <TableCell className="font-mono">{c.pid}</TableCell>
+                        <TableCell>{c.application_name || '-'}</TableCell>
+                        <TableCell>{c.usename || '-'}</TableCell>
+                        <TableCell>
+                          <Badge className="bg-red-500">{formatDuration(c.duration_seconds)}</Badge>
+                        </TableCell>
+                        <TableCell className="max-w-[300px] truncate">
+                          <pre className="text-xs">{c.query || '-'}</pre>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            </CollapsibleContent>
+          )}
+        </Collapsible>
+
+        {/* Long Running Queries */}
+        <Collapsible open={openSections.has('slow')} onOpenChange={() => toggleSection('slow')}>
+          <CollapsibleTrigger className="flex items-center gap-3 w-full p-3 rounded-lg hover:bg-muted/50 transition-colors">
+            {openSections.has('slow') ? (
+              <ChevronDown className="h-4 w-4 shrink-0" />
+            ) : (
+              <ChevronRight className="h-4 w-4 shrink-0" />
+            )}
+            <Clock
+              className={`h-4 w-4 shrink-0 ${slowCount > 0 ? 'text-yellow-500' : 'text-green-500'}`}
+            />
+            <span className="font-medium text-sm">
+              {slowCount} long-running {slowCount === 1 ? 'query' : 'queries'}
+            </span>
+            {slowCount > 0 && (
+              <Badge variant="outline" className="text-xs">
+                longest: {formatDuration(longestSlow)}
+              </Badge>
+            )}
+            {slowCount === 0 && <span className="text-xs text-muted-foreground">Healthy</span>}
+          </CollapsibleTrigger>
+          {slowCount > 0 && (
+            <CollapsibleContent>
+              <div className="rounded-md border ml-7 mt-1">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>PID</TableHead>
+                      <TableHead>User</TableHead>
+                      <TableHead>Duration</TableHead>
+                      <TableHead>State</TableHead>
+                      <TableHead>Query</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {health.longRunningQueries.map((q) => (
+                      <TableRow key={q.pid}>
+                        <TableCell className="font-mono">{q.pid}</TableCell>
+                        <TableCell>{q.usename || '-'}</TableCell>
+                        <TableCell>
+                          <Badge
+                            className={q.duration_seconds > 60 ? 'bg-red-500' : 'bg-yellow-500'}
+                          >
+                            {formatDuration(q.duration_seconds)}
+                          </Badge>
+                        </TableCell>
+                        <TableCell>{q.state}</TableCell>
+                        <TableCell className="max-w-[300px] truncate">
+                          <pre className="text-xs">{q.query}</pre>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            </CollapsibleContent>
+          )}
+        </Collapsible>
+
+        {/* Blocked Connections */}
+        <Collapsible
+          open={openSections.has('blocked')}
+          onOpenChange={() => toggleSection('blocked')}
+        >
+          <CollapsibleTrigger className="flex items-center gap-3 w-full p-3 rounded-lg hover:bg-muted/50 transition-colors">
+            {openSections.has('blocked') ? (
+              <ChevronDown className="h-4 w-4 shrink-0" />
+            ) : (
+              <ChevronRight className="h-4 w-4 shrink-0" />
+            )}
+            <Lock
+              className={`h-4 w-4 shrink-0 ${blockedCount > 0 ? 'text-red-500' : 'text-green-500'}`}
+            />
+            <span className="font-medium text-sm">
+              {blockedCount} blocked {blockedCount === 1 ? 'connection' : 'connections'}
+            </span>
+            {blockedCount > 0 && (
+              <Badge variant="outline" className="text-xs">
+                longest wait: {formatDuration(longestBlocked)}
+              </Badge>
+            )}
+            {blockedCount === 0 && (
+              <span className="text-xs text-muted-foreground">No lock contention</span>
+            )}
+          </CollapsibleTrigger>
+          {blockedCount > 0 && (
+            <CollapsibleContent>
+              <div className="rounded-md border ml-7 mt-1">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Blocked PID</TableHead>
+                      <TableHead>Blocked App</TableHead>
+                      <TableHead>Waiting</TableHead>
+                      <TableHead>Blocking PID</TableHead>
+                      <TableHead>Blocking App</TableHead>
+                      <TableHead>Blocking Query</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {health.blockedConnections.map((c) => (
+                      <TableRow key={c.blocked_pid}>
+                        <TableCell className="font-mono">{c.blocked_pid}</TableCell>
+                        <TableCell>{c.blocked_app || '-'}</TableCell>
+                        <TableCell>
+                          <Badge className="bg-red-500">{formatDuration(c.waiting_seconds)}</Badge>
+                        </TableCell>
+                        <TableCell className="font-mono">{c.blocking_pid}</TableCell>
+                        <TableCell>{c.blocking_app || '-'}</TableCell>
+                        <TableCell className="max-w-[200px] truncate">
+                          <pre className="text-xs">{c.blocking_query || '-'}</pre>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            </CollapsibleContent>
+          )}
+        </Collapsible>
+      </CardContent>
+    </Card>
+  );
+}

--- a/package/ui/modules/db-health/components/connection-sankey.tsx
+++ b/package/ui/modules/db-health/components/connection-sankey.tsx
@@ -1,0 +1,207 @@
+'use client';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Sankey, Tooltip, Layer, Rectangle } from 'recharts';
+import { ConnectionTopology } from '../lib/api';
+
+interface ConnectionSankeyProps {
+  topology: ConnectionTopology[];
+  maxConnections: number;
+}
+
+const SERVICE_COLORS = [
+  '#22c55e',
+  '#8b5cf6',
+  '#f59e0b',
+  '#ef4444',
+  '#06b6d4',
+  '#ec4899',
+  '#14b8a6',
+  '#f97316',
+];
+
+function SankeyNode({
+  x,
+  y,
+  width,
+  height,
+  index,
+  payload,
+}: {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  index: number;
+  payload: { name: string; value: number; isDatabase?: boolean };
+}) {
+  const isDb = payload.isDatabase;
+  const color = isDb ? '#3b82f6' : SERVICE_COLORS[index % SERVICE_COLORS.length];
+
+  return (
+    <Layer>
+      <Rectangle
+        x={x}
+        y={y}
+        width={width}
+        height={height}
+        fill={color}
+        fillOpacity={0.8}
+        rx={4}
+        ry={4}
+      />
+      <text
+        x={isDb ? x - 8 : x + width + 8}
+        y={y + height / 2}
+        textAnchor={isDb ? 'end' : 'start'}
+        dominantBaseline="central"
+        className="fill-foreground text-xs"
+      >
+        {payload.name} ({payload.value})
+      </text>
+    </Layer>
+  );
+}
+
+function SankeyLink({
+  sourceX,
+  targetX,
+  sourceY,
+  targetY,
+  sourceControlX,
+  targetControlX,
+  linkWidth,
+  index,
+}: {
+  sourceX: number;
+  targetX: number;
+  sourceY: number;
+  targetY: number;
+  sourceControlX: number;
+  targetControlX: number;
+  linkWidth: number;
+  index: number;
+}) {
+  return (
+    <Layer>
+      <path
+        d={`
+          M${sourceX},${sourceY + linkWidth / 2}
+          C${sourceControlX},${sourceY + linkWidth / 2}
+            ${targetControlX},${targetY + linkWidth / 2}
+            ${targetX},${targetY + linkWidth / 2}
+          L${targetX},${targetY - linkWidth / 2}
+          C${targetControlX},${targetY - linkWidth / 2}
+            ${sourceControlX},${sourceY - linkWidth / 2}
+            ${sourceX},${sourceY - linkWidth / 2}
+          Z
+        `}
+        fill={SERVICE_COLORS[index % SERVICE_COLORS.length]}
+        fillOpacity={0.3}
+        strokeWidth={0}
+      />
+    </Layer>
+  );
+}
+
+export function ConnectionSankey({ topology, maxConnections }: ConnectionSankeyProps) {
+  if (topology.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm font-medium">Connection Flow</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-center py-8 text-muted-foreground">
+            No active connections detected.
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const totalConnections = topology.reduce((sum, t) => sum + t.total, 0);
+
+  const nodes = [
+    ...topology.map((t) => ({
+      name: t.application_name || '(unnamed)',
+      value: t.total,
+    })),
+    {
+      name: `PostgreSQL`,
+      value: totalConnections,
+      isDatabase: true,
+    },
+  ];
+
+  const dbIndex = nodes.length - 1;
+
+  const links = topology.map((t, i) => ({
+    source: i,
+    target: dbIndex,
+    value: t.total,
+  }));
+
+  const data = { nodes, links };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm font-medium">
+          Connection Flow
+          <span className="text-muted-foreground font-normal ml-2">
+            {totalConnections} / {maxConnections} connections
+          </span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Sankey
+          width={700}
+          height={Math.max(200, topology.length * 50)}
+          data={data}
+          nodeWidth={10}
+          nodePadding={24}
+          margin={{ left: 0, right: 0, top: 10, bottom: 10 }}
+          link={
+            <SankeyLink
+              index={0}
+              sourceX={0}
+              targetX={0}
+              sourceY={0}
+              targetY={0}
+              sourceControlX={0}
+              targetControlX={0}
+              linkWidth={0}
+            />
+          }
+          node={
+            <SankeyNode
+              x={0}
+              y={0}
+              width={0}
+              height={0}
+              index={0}
+              payload={{ name: '', value: 0 }}
+            />
+          }
+        >
+          <Tooltip
+            content={({ payload }) => {
+              if (!payload || !payload.length) return null;
+              const data = payload[0].payload;
+              if (data.source && data.target) {
+                return (
+                  <div className="bg-popover border rounded-lg p-2 text-sm shadow-md">
+                    <p className="font-medium">{data.source.name}</p>
+                    <p className="text-muted-foreground">{data.value} connections</p>
+                  </div>
+                );
+              }
+              return null;
+            }}
+          />
+        </Sankey>
+      </CardContent>
+    </Card>
+  );
+}

--- a/package/ui/modules/db-health/index.ts
+++ b/package/ui/modules/db-health/index.ts
@@ -1,4 +1,4 @@
-import { Activity, BarChart3, Search, Database } from 'lucide-react';
+import { Activity, BarChart3, Search, Database, Network } from 'lucide-react';
 import { UIModuleManifest } from '../registry';
 
 export const dbHealthUIModule: UIModuleManifest = {
@@ -10,5 +10,6 @@ export const dbHealthUIModule: UIModuleManifest = {
     { label: 'Overview', href: '/health', icon: Database },
     { label: 'Slow Queries', href: '/health/slow-queries', icon: Search },
     { label: 'Table Sizes', href: '/health/table-sizes', icon: BarChart3 },
+    { label: 'Connections', href: '/health/connections', icon: Network },
   ],
 };

--- a/package/ui/modules/db-health/lib/api.ts
+++ b/package/ui/modules/db-health/lib/api.ts
@@ -62,3 +62,49 @@ export async function getSlowQueries(minDuration = 5): Promise<SlowQuery[]> {
 export async function getTables(): Promise<TableInfo[]> {
   return apiClient.get<TableInfo[]>('/api/modules/health/tables');
 }
+
+export interface ConnectionTopology {
+  application_name: string | null;
+  total: number;
+  active: number;
+  idle: number;
+  idle_in_transaction: number;
+}
+
+export interface IdleTransaction {
+  pid: number;
+  usename: string | null;
+  application_name: string | null;
+  client_addr: string | null;
+  duration_seconds: number;
+  query: string | null;
+  state: string;
+}
+
+export interface BlockedConnection {
+  blocked_pid: number;
+  blocked_user: string | null;
+  blocked_app: string | null;
+  blocked_query: string | null;
+  waiting_seconds: number;
+  blocking_pid: number;
+  blocking_user: string | null;
+  blocking_app: string | null;
+  blocking_query: string | null;
+}
+
+export interface ConnectionHealthData {
+  idleInTransaction: IdleTransaction[];
+  longRunningQueries: SlowQuery[];
+  blockedConnections: BlockedConnection[];
+}
+
+export async function getConnectionTopology(): Promise<ConnectionTopology[]> {
+  return apiClient.get<ConnectionTopology[]>('/api/modules/health/connections/topology');
+}
+
+export async function getConnectionHealth(minDuration = 5): Promise<ConnectionHealthData> {
+  return apiClient.get<ConnectionHealthData>('/api/modules/health/connections/health', {
+    params: { min_duration: minDuration },
+  });
+}

--- a/package/ui/modules/db-health/pages/connections.tsx
+++ b/package/ui/modules/db-health/pages/connections.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { PageHeader } from '@/components/page-header';
+import { StatCard } from '@/components/stat-card';
+import { Button } from '@/components/ui/button';
+import { Network, Activity, Pause, AlertTriangle, RefreshCw } from 'lucide-react';
+import { ConnectionSankey } from '../components/connection-sankey';
+import { ConnectionHealthAlerts } from '../components/connection-health-alerts';
+import * as healthApi from '../lib/api';
+import { ConnectionOverview, ConnectionTopology, ConnectionHealthData } from '../lib/api';
+
+export function ConnectionsPage() {
+  const [overview, setOverview] = useState<ConnectionOverview | null>(null);
+  const [topology, setTopology] = useState<ConnectionTopology[]>([]);
+  const [health, setHealth] = useState<ConnectionHealthData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const fetchData = useCallback(async () => {
+    try {
+      const [overviewData, topologyData, healthData] = await Promise.all([
+        healthApi.getOverview(),
+        healthApi.getConnectionTopology(),
+        healthApi.getConnectionHealth(),
+      ]);
+      setOverview(overviewData.connections);
+      setTopology(topologyData);
+      setHealth(healthData);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch connection data');
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData().finally(() => setIsLoading(false));
+  }, [fetchData]);
+
+  const handleRefresh = async () => {
+    setIsRefreshing(true);
+    await fetchData();
+    setIsRefreshing(false);
+  };
+
+  if (isLoading) return <div>Loading connections...</div>;
+  if (error) return <div className="text-red-500">Error: {error}</div>;
+
+  return (
+    <div>
+      <PageHeader
+        title="Connection Visualizer"
+        description="Visualize service connections, health, and lock contention"
+        breadcrumbs={[
+          { label: 'Home', href: '/' },
+          { label: 'Health', href: '/health' },
+          { label: 'Connections' },
+        ]}
+        actions={
+          <Button variant="outline" size="sm" onClick={handleRefresh} disabled={isRefreshing}>
+            <RefreshCw className={`h-4 w-4 mr-2 ${isRefreshing ? 'animate-spin' : ''}`} />
+            Refresh
+          </Button>
+        }
+      />
+
+      {/* Stat Cards */}
+      {overview && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+          <StatCard
+            label="Total Connections"
+            value={`${overview.total} / ${overview.max_connections}`}
+            icon={Network}
+          />
+          <StatCard label="Active" value={overview.active} icon={Activity} />
+          <StatCard label="Idle" value={overview.idle} icon={Pause} />
+          <StatCard
+            label="Idle in Transaction"
+            value={overview.idle_in_transaction}
+            icon={AlertTriangle}
+            className={overview.idle_in_transaction > 0 ? 'border-red-500/50' : ''}
+          />
+        </div>
+      )}
+
+      {/* Sankey Flow Diagram */}
+      <div className="mb-6">
+        <ConnectionSankey topology={topology} maxConnections={overview?.max_connections ?? 100} />
+      </div>
+
+      {/* Health Alerts */}
+      {health && <ConnectionHealthAlerts health={health} />}
+    </div>
+  );
+}


### PR DESCRIPTION
Add a new "Connections" page under Database Health that visualizes service-to-database connections with a Sankey flow diagram, summary stat cards, and health alerts for idle-in-transaction, long-running queries, and blocked connections.